### PR TITLE
Adds ip_ranges variant of deploy_solo job

### DIFF
--- a/src/jobs/deploy_solo-ip_ranges.yml
+++ b/src/jobs/deploy_solo-ip_ranges.yml
@@ -1,0 +1,34 @@
+description: >
+  Kicks off a chef-solo deployment for the specified targets.
+executor: ruby/default
+circleci_ip_ranges: true
+steps:
+  - install_cli:
+      ruby-version: << parameters.ruby-version >>
+      dreamops-version: << parameters.dreamops-version >>
+  - run:
+      name: Deploy to targets
+      command: <<include(scripts/deploy_solo.sh)>>
+      environment:
+        FORCE_SETUP: << parameters.force-setup >>
+        SSH_KEY: << parameters.ssh-key >>
+        TARGETS: << parameters.targets >>
+parameters:
+  ruby-version:
+    default: 3.1.2
+    description: The version of the ruby to use.
+    type: string
+  dreamops-version:
+    default: '>= 0.8.0'
+    description: The version of the dream-ops gem to use.
+    type: string
+  force-setup:
+    description: Always run setup.
+    type: boolean
+    default: false
+  ssh-key:
+    description: The ssh key to use for solo deployments
+    type: env_var_name
+  targets:
+    description: Deploy targets separated by whitespace.
+    type: string


### PR DESCRIPTION
Currently, the job option `circleci_ip_ranges` does not have access to pipeline parameters as discussed in this [thread](https://discuss.circleci.com/t/ip-ranges-open-preview/40864/2).

For now, the bandaid is to offer an alternate `deploy_solo-ip_ranges` job that enables it.